### PR TITLE
Configure serial port input to be more raw

### DIFF
--- a/Src/orbuculum.c
+++ b/Src/orbuculum.c
@@ -1127,6 +1127,7 @@ int serialFeeder( void )
             return -3;
         }
 
+        settings.c_iflag &= ~( ISTRIP | INLCR | IGNCR | ICRNL | IXON | IXOFF );
         settings.c_lflag &= ~( ICANON | ECHO | ECHOE | ISIG );
         settings.c_cflag &= ~PARENB; /* no parity */
         settings.c_cflag &= ~CSTOPB; /* 1 stop bit */


### PR DESCRIPTION
On my machine (Linux, Debian Jessie), the default terminal input settings includes flags like IXON and ICRNL that can mangle binary input. This patch clears those flags and others that seem like they would cause trouble.

I would prefer to use something like `cfmakeraw()`, which seems to be available on my machine, but apparently it's not in the POSIX standard. 