### PR TITLE
Fix bug where only the usbFeeder serviced remote clients

### DIFF
--- a/Src/orbuculum.c
+++ b/Src/orbuculum.c
@@ -1144,6 +1144,7 @@ int serialFeeder( void )
 
         while ( ( t = read( f, cbw, TRANSFER_SIZE ) ) > 0 )
         {
+            _sendToClients( t, cbw );
             unsigned char *c = cbw;
 
             while ( t-- )
@@ -1185,6 +1186,7 @@ int fileFeeder( void )
 
     while ( ( t = read( f, cbw, TRANSFER_SIZE ) ) > 0 )
     {
+        _sendToClients( t, cbw );
         unsigned char *c = cbw;
 
         while ( t-- )


### PR DESCRIPTION
`orbcat` and `orbtop` wouldn't work with file or serial input otherwise.